### PR TITLE
Revert "allow superstructuretuning to not have to disable when using different elevator heights"

### DIFF
--- a/src/main/java/frc/lib/util/tuning/SuperstructureTuning.java
+++ b/src/main/java/frc/lib/util/tuning/SuperstructureTuning.java
@@ -64,8 +64,8 @@ public class SuperstructureTuning extends Command {
 
 	@Override
 	public void initialize() {
-		setHeight.onTrue(new ExtendElevator(elevator, endeffector));
-		setAngle.onTrue(Commands.run(() -> endeffector.setAngle(() -> targetAngle)).until(() -> endeffector.isAtSetpoint()));
+		setHeight.whileTrue(new ExtendElevator(elevator, endeffector));
+		setAngle.whileTrue(Commands.run(() -> endeffector.setAngle(() -> targetAngle)));
 		intakeRun.whileTrue(Commands.run(() -> endeffector.runIntake(volt_target))).whileFalse(Commands.run(() -> endeffector.runIntake(Volts.zero())));
 	}
 

--- a/src/main/java/frc/robot/commands/ExtendElevator.java
+++ b/src/main/java/frc/robot/commands/ExtendElevator.java
@@ -25,6 +25,8 @@ public class ExtendElevator extends Command {
 	public ExtendElevator(Elevator elevator, EndEffector endeffector) {
 		this.elevator = elevator;
 		this.endEffector = endeffector;
+
+		addRequirements(elevator, endeffector);
 	}
 
 	@Override


### PR DESCRIPTION
Reverts Angelbots1339/2025Competition#33
I forgot to test the teleop, and it seems this breaks the default command for the endeffector because I apparantly removed the requirements on the extendelevator.